### PR TITLE
Add break analysis xml to test Jenkins plugin

### DIFF
--- a/Test-break-the-analysis.xml
+++ b/Test-break-the-analysis.xml
@@ -1,0 +1,10 @@
+<report tool="test" date="2020-01-01">
+    <findings>
+        <finding severity="high" type="container">
+            <tool name="Custom Tool" category="foo" code="bar-42" />
+            <host>
+                <port num="5" />
+            </host>
+        </finding>
+    </findings>
+</report>


### PR DESCRIPTION
Tyler created `test-break-the-analysis.xml` for testing the Jenkins plugin when Policies are violated and the user wants to break the build.